### PR TITLE
add setter for NSView's 'tag' property

### DIFF
--- a/DMPathBar/DMPathBarItem.h
+++ b/DMPathBar/DMPathBarItem.h
@@ -39,6 +39,7 @@ IB_DESIGNABLE
 // Helper Methods
 - (NSSize) bestContentSizeWithMax:(NSSize) maxSize;
 - (void) setCompressed:(BOOL) aCompressed animated:(BOOL) aAnimated;
+- (void) setTag:(NSInteger)tag;
 - (void) layoutSubviews;
 
 @end

--- a/DMPathBar/DMPathBarItem.m
+++ b/DMPathBar/DMPathBarItem.m
@@ -46,6 +46,7 @@
 @interface DMPathBarItem () {
 	NSTextField				*fldTitle;
 	DMPathBarGradient		*gradient;
+	NSInteger				_tag;
 }
 
 @property (nonatomic,readonly)	NSRect		titleRect;
@@ -206,6 +207,14 @@
 	}
 	
 	[self layoutSubviews];
+}
+
+- (void) setTag:(NSInteger)tag {
+	_tag = tag;
+}
+
+- (NSInteger)tag {
+	return _tag;
 }
 
 - (void) layoutSubviews {


### PR DESCRIPTION
add a setter and storage for NSViews's tag property. Having the tag available, can help to identify the PathBarItem in the PathBar action
